### PR TITLE
Updated package.xml to depend on python-requests

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -44,6 +44,7 @@
   <build_depend>rospy</build_depend>
   <run_depend>diagnostic_msgs</run_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>python-requests</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
This way you won't have to instruct users to install python-requests separately.
See http://docs.ros.org/indigo/api/catkin/html/howto/format1/python_module_dependencies.html
for a more detailed explanation.

PS - Great package! Thank you for taking the initiative to integrate ROS with openHAB :)
