### PR TITLE
[enhance] Allow host/port for iot server via launch args.

### DIFF
--- a/launch/iot.launch
+++ b/launch/iot.launch
@@ -1,7 +1,18 @@
 <launch>
   <arg name="configfile" default="$(find iot_bridge)/config/items.yaml" />
-  
-  <node name="iot" pkg="iot_bridge" type="iot_bridge" output="screen">
-    <rosparam file="$(arg configfile)" command="load" />
+  <arg name="iot_server_host" default="0" doc="Host where an IoT server (e.g. openHAB) is running. IP address/hostname string. NOTE: 'use_conffile' must be set 1/true for this to be used. " />
+  <arg name="iot_server_port" default="0" doc="port number for an IoT server (e.g. openHAB). NOTE: 'use_conffile' must be set 1/true for this to be used." />
+  <arg name="use_conffile" default="1" doc="If 0/false (default), parameters need passed via argument of this launch. If true/1, a yaml file passed via 'configfile' will be used." />
+
+  <arg name="NODENAME_IOT_SERVER" default="iot_server" />
+
+  <group unless="$(arg use_conffile)">
+    <!-- Set parameter as private iot server node. -->
+    <param name="$(arg NODENAME_IOT_SERVER)/host" type="str" value="$(arg iot_server_host)" />
+    <param name="port" type="int" value="$(arg iot_server_port)" />
+  </group>
+
+  <node name="$(arg NODENAME_IOT_SERVER)" pkg="iot_bridge" type="iot_bridge" output="screen">
+    <rosparam if="$(arg use_conffile)" file="$(arg configfile)" command="load" />
   </node>
 </launch>

--- a/launch/openhab_bridge.launch
+++ b/launch/openhab_bridge.launch
@@ -1,0 +1,17 @@
+<!-- Parameters for openHAB -->
+<launch>
+  <arg name="oh_configfile" default="$(find iot_bridge)/config/items.yaml" />
+  <!-- <arg name="oh_server_host" default="localhost" doc="Where an openHAB is running. Either IP address or hostname string." /> -->
+  <arg name="oh_server_host" default="0" doc="Where an openHAB is running. Either IP address or hostname string." />
+  <arg name="oh_server_port" default="8080" />
+
+  <arg name="use_conffile" unless="$(arg oh_server_host)" value="1"
+       doc="If 0/false (default), parameters need passed via argument of this launch. If true/1, a yaml file passed via 'configfile' will be used." />
+  
+  <include file="$(find iot_bridge)/launch/iot.launch">
+    <arg name="configfile" value="$(arg oh_configfile)" />
+    <arg name="iot_server_host" value="$(arg oh_server_host)" />
+    <arg name="iot_server_port" value="$(arg oh_server_port)" />
+    <arg name="use_conffile" value="$(arg use_conffile)" />
+  </include>
+</launch>


### PR DESCRIPTION
tl;dr Opened a PR just for sharing purpose. This does not work and is not ideal thus **should never be merged.**

**Motivation**
I thought if we could specify iot server's hostname and/or port via argument for a launch file as following for example, it'd be convenient eps. during development where frequently switching servers.

```
$ roslaunch iot_bridge openhab_bridge.launch oh_server_host:=130s-rpi2
```

**Approach**
- Allow passing args via launch.
- For backward compatibility, and also for the future where we may want to pass a lot of parameter items, passing config yaml file needs to remain available.
- Split param mechanism into another launch to avoid too much complication in the original `iot.launch` (although this commit ended up complicated it enough).

**Result**
- Simply this does not. if/unless logic of launch requires the value to be bool.
  ```
  $ roslaunch iot_bridge openhab_bridge.launch oh_server_host:=host_name_a
  :
  host_name_a is not a 'bool' type
  The traceback for the exception was written to the log file
  ```
- Come to think of it, I've never seen launch files that allow both arg and config file for setting the same arg. So people might have tried but given up?